### PR TITLE
sub home directory with '~'

### DIFF
--- a/send_text.py
+++ b/send_text.py
@@ -189,6 +189,7 @@ class RBoxSourceCodeCommand(sublime_plugin.TextCommand):
         if not fname:
             sublime.error_message("Save the file!")
             return
+        fname = re.sub(os.path.expanduser("~"), "~", fname)
         cmd = "source(\"" + escape_dq(fname) + "\")"
         send_text(view, cmd)
 


### PR DESCRIPTION
When sending code to remote machine where files are `rsync`'d,  home directory on remote machine may generally be different.  Helpful to use `~` instead of expanded path.
